### PR TITLE
CMR-368: Added dc:creator for Artists (Kuenstler)

### DIFF
--- a/src/main/resources/mets2xmetadissplus.xsl
+++ b/src/main/resources/mets2xmetadissplus.xsl
@@ -67,6 +67,7 @@
         <!-- dc:creator -->
         <apply-templates select="mods:name[@type='personal' and mods:role/mods:roleTerm='aut']" mode="dc:creator"/>
         <apply-templates select="mods:name[@type='personal' and mods:role/mods:roleTerm='cmp']" mode="dc:creator"/>
+        <apply-templates select="mods:name[@type='personal' and mods:role/mods:roleTerm='art']" mode="dc:creator"/>
         <!-- dc:subject -->
         <apply-templates select="mods:classification"/>
         <!-- dcterms:tableOfContents -->


### PR DESCRIPTION
Added dc:creator for mods:name[@type='personal' and mods:role/mods:roleTerm='art']
https://jira.slub-dresden.de/browse/CMR-368