### PR TITLE
Fixes dissemination error for multiple issn's.

### DIFF
--- a/src/main/resources/mets2xmetadissplus.xsl
+++ b/src/main/resources/mets2xmetadissplus.xsl
@@ -447,8 +447,8 @@
 
     <template match="mods:relatedItem[@type='original']">
         <variable name="title" select="mods:titleInfo[1]/mods:title[1]"/>
-        <variable name="issn" select="mods:identifier[@type='issn']"/>
-        <variable name="urn" select="mods:identifier[@type='urn']"/>
+        <variable name="issn" select="mods:identifier[@type='issn'][1]"/>
+        <variable name="urn" select="mods:identifier[@type='urn'][1]"/>       
 
         <if test="string-length($title)>0">
             <dcterms:isPartOf xsi:type="ddb:noScheme">


### PR DESCRIPTION
string-length throws error if there are multiple issn's as mods:identifier-elements.