### PR TITLE
Count only files from "DOWNLOAD" file group with "ARCHIVE" signature

### DIFF
--- a/src/main/resources/mets2xmetadissplus.xsl
+++ b/src/main/resources/mets2xmetadissplus.xsl
@@ -152,7 +152,7 @@
 
         <!-- ddb:fileNumber -->
         <ddb:fileNumber>
-            <value-of select="count(//mets:fileSec//mets:file)"/>
+            <value-of select="count(//mets:fileSec/mets:fileGrp[@USE='DOWNLOAD']/mets:file[@USE='ARCHIVE'])"/>
         </ddb:fileNumber>
 
         <!-- Skip: ddb:fileProperties -->


### PR DESCRIPTION
Only files within <mets:fileGrp[@USE="DOWNLOAD"]> and matching
<mets:file[@USE="ARCHIVE"] should be considered when calculating the
number of archivable files.

Resolves https://jira.slub-dresden.de/browse/CMR-435
> METS Dissemination muss gelöschte Datastreams anzeigen